### PR TITLE
Corrects the errors in C++/Errors/UpperLowerDirty.cpp

### DIFF
--- a/C++/Errors/UpperLowerDirty.cpp
+++ b/C++/Errors/UpperLowerDirty.cpp
@@ -6,16 +6,15 @@ using namespace std;
 
 int main()
 {
-char str1 [30], temp[30];
+char str1 [30];
 cout << "Enter the string:";
 cin >> str1;
 
-strcpy (temp, str1);
-strupr(temp);
-cout << "strupr (tmp) : " << temp << endl;
+strupr(str1);
+cout << "strupr (tmp) : " << str1 << endl;
 
-strlwr(temp);
-cout << "strlwr (tmp) : " << temp << endl;
+strlwr(str1);
+cout << "strlwr (tmp) : " << str1 << endl;
 system("pause");
  
 return 0;


### PR DESCRIPTION
Hi everyone 😃

This Pull Request has been created in order to correct the issue #125, in the context of the HacktoberFest 2021.

It corrects the code in order to compile and display the specified string in upper case and lower case using the functions `strupr` and `strlwr`.
It also removes an unecessary variable.

Note: Since the README file, next to the cpp file is empty, I have find any description on exactly what to specify in this Pull Request description or about the compiler used by this organisation to compile the source code in order to make sure that everything works properly. If you have any information about that, please, add a comment on the Pull Request, and I will adapt this Pull Request accordingly 😉

Note2: The solution is currently limited to a string of size `30`, as it was before I created this Pull Request.
Should this be improved ?

